### PR TITLE
avoid deprecated warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Get parameters:
 ### Install dependencies.
 Resolve and install dependencies.
 ```
-npm install --dev
+npm install --only=dev
 ```
 
 ### Build


### PR DESCRIPTION
Usage of the `--dev` option is deprecated. Use `--only=dev` instead.