### PR TITLE
Make the warning message for pending attestation a little bit more educational and informative

### DIFF
--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -76,7 +76,7 @@ function upgrade_verify(ots, hash, hashType, filename) {
                 	}
             	});
     		} else {
-                warning('The Bitcoin transacation is unconfirmed. The attestation is still pending. Once the transaction confirms, this file will be updated.');
+                warning('The Bitcoin transaction is unconfirmed. The attestation is still pending. Once the transaction confirms, this file will be updated.');
 			}
 		} else {
 			var text = "";

--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -76,7 +76,7 @@ function upgrade_verify(ots, hash, hashType, filename) {
                 	}
             	});
     		} else {
-                warning('Pending attestation');
+                warning('The Bitcoin transacation is unconfirmed. The attestation is still pending. Once the transaction confirms, this file will be updated.');
 			}
 		} else {
 			var text = "";


### PR DESCRIPTION
To make it easier to understand what is going on for people who don't really know that much about OTS.

The text is

`The Bitcoin transaction is unconfirmed. The attestation is still pending. Once the transaction confirms, this file will be updated.`