### PR TITLE
Digest timestamp verify fix

### DIFF
--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -54,6 +54,7 @@ function upgrade_verify(ots, hash, hashType, filename) {
         const bytes = detachedOts.serializeToBytes();
     	if(changed){
         	//success('Timestamp has been successfully upgraded!');
+            filename = filename || hash + ".ots";
         	download(filename, bytes);
 
         	// update proof

--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -575,7 +575,7 @@ var Proof = {
     const algorithm = getParameterByName('algorithm');
 	if(digest) {
 		Hashes.init();
-		Hashes.set(digest, algorithm);
+		Hashes.set(algorithm, digest);
 		Document.show();
 	}
 	const ots = getParameterByName('ots');


### PR DESCRIPTION
Interchanged parameters are fixed and a file name is provided while downloading upgraded OTS